### PR TITLE
Make PREFIX, MANPATH and CFLAGS optional variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OBJS=		calmwm.o screen.o xmalloc.o client.o menu.o \
 
 CPPFLAGS+=	`pkg-config --cflags fontconfig x11 xft xinerama xrandr`
 
-CFLAGS?=		-Wall -O2 -g -D_GNU_SOURCE
+CFLAGS?=	-Wall -O2 -g -D_GNU_SOURCE
 
 LDFLAGS+=	`pkg-config --libs fontconfig x11 xft xinerama xrandr`
 


### PR DESCRIPTION
This change will make it possible to override PREFIX, MANPATH and CFLAGS
using environment variables. This makes the Makefile a little more
flexible, benefiting both endusers and those porting to package systems
like FreeBSD Ports and pkgsrc.
