### PR TITLE
Add support to build using Hombrew on Mac OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ OBJS=		calmwm.o screen.o xmalloc.o client.o menu.o \
 CPPFLAGS+=	`pkg-config --cflags fontconfig x11 xft xinerama xrandr`
 
 CFLAGS?=	-Wall -O2 -g -D_GNU_SOURCE
+CFLAGS+=	`[ "\`uname -s\`" = "Darwin" ] && echo "-DHAVE_STRLCPY -DHAVE_STRLCAT"`
 
 LDFLAGS+=	`pkg-config --libs fontconfig x11 xft xinerama xrandr`
 

--- a/calmwm.h
+++ b/calmwm.h
@@ -24,8 +24,12 @@
 /* prototypes for portable-included functions */
 char *fgetln(FILE *, size_t *);
 long long strtonum(const char *, long long, long long, const char **);
+#ifndef HAVE_STRLCPY
 size_t strlcpy(char *, const char *, size_t);
+#endif
+#ifndef HAVE_STRLCAT
 size_t strlcat(char *, const char *, size_t);
+#endif
 
 #include <X11/XKBlib.h>
 #include <X11/Xatom.h>


### PR DESCRIPTION
Omit compiling strlcpy and strlcat on Mac OS X due to compilation errors:

```
In file included from calmwm.c:36:
./calmwm.h:28:8: error: conflicting types for '__builtin___strlcat_chk'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/usr/include/secure/_string.h:111:3: note:
      expanded from macro 'strlcat'
  __builtin___strlcat_chk (dest, src, len, __darwin_obsz (dest))
```

I welcome feedback on how to improve the proposed changes.
