### PR TITLE
Is it my distro or, keypad presses don't get registered on key-bind shortcuts?

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 This is a port of OpenBSD's excellent cwm[0] to Linux and other
-Unices.
+Unices. 
 
     cwm is a window manager for X11 which contains many features that
     concentrate on the efficiency and transparency of window


### PR DESCRIPTION
Btw don't merge this, it is just that this repo lacked issues page.

I'm not sure why but key-bind 4-KP_1 test_command_here ,doesn't get registered while key-bind 4-1 test_command_here gets registered.

Here's the video with xev window, .cwmrc shown, I click super+enter, super+1, super+numpad_1 and 2 out of 3 terminal windows show up.
https://streamable.com/3vk0n
