### PR TITLE
use PKGCONFIG for cross compilation in gentoo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ OBJS=		calmwm.o screen.o xmalloc.o client.o menu.o \
 		kbfunc.o strlcpy.o strlcat.o y.tab.o \
 		strtonum.o reallocarray.o
 		
-PKGCONFIG?=	pkg-config
+PKG_CONFIG?=	pkg-config
 
-CPPFLAGS+=	`${PKGCONFIG} --cflags x11 xft xrandr`
+CPPFLAGS+=	`${PKG_CONFIG} --cflags x11 xft xrandr`
 
 CFLAGS?=	-Wall -O2 -g -D_GNU_SOURCE
 
-LDFLAGS+=	`${PKGCONFIG} --libs x11 xft xrandr`
+LDFLAGS+=	`${PKG_CONFIG} --libs x11 xft xrandr`
 
 MANPREFIX?=	${PREFIX}/share/man
 

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,14 @@ OBJS=		calmwm.o screen.o xmalloc.o client.o menu.o \
 		search.o util.o xutil.o conf.o xevents.o group.o \
 		kbfunc.o strlcpy.o strlcat.o y.tab.o \
 		strtonum.o reallocarray.o
+		
+PKGCONFIG?=	pkg-config
 
-CPPFLAGS+=	`pkg-config --cflags x11 xft xrandr`
+CPPFLAGS+=	`${PKGCONFIG} --cflags x11 xft xrandr`
 
 CFLAGS?=	-Wall -O2 -g -D_GNU_SOURCE
 
-LDFLAGS+=	`pkg-config --libs x11 xft xrandr`
+LDFLAGS+=	`${PKGCONFIG} --libs x11 xft xrandr`
 
 MANPREFIX?=	${PREFIX}/share/man
 


### PR DESCRIPTION
needed for ebuild validity across different platforms which define their specific PKGCONFIG variable

Tested on gentoo on amd64 should be fine for everyone.