### PR TITLE
Use bison(1) if yacc(1) is not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cwm
+y.tab.c

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,15 @@ LDFLAGS+=	`${PKG_CONFIG} --libs x11 xft xrandr`
 
 MANPREFIX?=	${PREFIX}/share/man
 
+YACC=           $(if $(shell command -v yacc >/dev/null),yacc,bison --yacc)
+
 all: ${PROG}
 
 clean:
 	rm -f ${OBJS} ${PROG} y.tab.c
 
 y.tab.c: parse.y
-	yacc parse.y
+	$(YACC) parse.y
 
 ${PROG}: ${OBJS} y.tab.o
 	${CC} ${OBJS} ${LDFLAGS} -o ${PROG}


### PR DESCRIPTION
Avoids having to install `yacc` on linux when `bison` is generally the default. This uses the `--yacc` option so the generated files are still the same.