### PR TITLE
Fix transparency of 32 bit client's border

### DIFF
--- a/client.c
+++ b/client.c
@@ -596,7 +596,7 @@ client_draw_border(struct client_ctx *cc)
 		pixel = sc->xftcolor[CWM_COLOR_BORDER_URGENCY].pixel;
 
 	XSetWindowBorderWidth(X_Dpy, cc->win, (unsigned int)cc->bwidth);
-	XSetWindowBorder(X_Dpy, cc->win, pixel);
+	XSetWindowBorder(X_Dpy, cc->win, pixel | (0xffu << 24));
 }
 
 static void


### PR DESCRIPTION
Hello this fixes the weird semi-transparency some apps (firefox, alacritty and more) have when using cwm with a compositor. The issue seems to be that the highest significant byte of the color is not initialized.