### PR TITLE
explicitly specify integer size in numberstring

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -22,6 +22,7 @@
 %{
 
 #include <sys/types.h>
+#include <inttypes.h>
 #include "queue.h"
 
 #include <ctype.h>
@@ -108,7 +109,7 @@ string		: string STRING			{
 
 numberstring	: NUMBER				{
 			char	*s;
-			if (asprintf(&s, "%lld", $1) == -1) {
+			if (asprintf(&s, "%" PRId64, $1) == -1) {
 				yyerror("string: asprintf");
 				YYERROR;
 			}


### PR DESCRIPTION
This removes the warning on systems with `long int` as 64-bit signed integer.
```
cc -c -Wall -O2 -g -D_GNU_SOURCE `pkg-config --cflags x11 xft xrandr` parse.c
parse.y: In function ‘yyparse’:
parse.y:111:42: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 3 has type ‘int64_t’ {aka ‘long int’} [-Wformat=]
  111 |                         if (asprintf(&s, "%lld", $1) == -1) {
      |                                          ^~~~~~  ~~~~~~~~~~~~
      |                                                             |
      |                                                             int64_t {aka long int}
```